### PR TITLE
Update _repeater_field_template.blade.php

### DIFF
--- a/resources/views/partials/fields/_repeater_field_template.blade.php
+++ b/resources/views/partials/fields/_repeater_field_template.blade.php
@@ -2,9 +2,9 @@
     <div class="card repeater-item" data-sort="@{{block_key}}">
         <div class="card-header">
             <h5 class="actions">
-                <span class="action card-handle icon-size-fullscreen" data-parent-container-key="@{{name}}"></span>
-                <span class="action icon-plus" data-action="click->fields--repeater#addBlockAfter"></span>
-                <span class="action icon-minus" data-action="click->fields--repeater#deleteBlock"></span>
+                <span class="action card-handle icon-size-fullscreen" data-parent-container-key="@{{name}}">Drag</span>
+                <span class="action icon-plus" data-action="click->fields--repeater#addBlockAfter">Add</span>
+                <span class="action icon-minus" data-action="click->fields--repeater#deleteBlock">Remove</span>
                 <span class="badge badge-light pull-right"
                       data-target="fields--repeater.repeaterBlockCount">@{{block_count}}</span>
             </h5>


### PR DESCRIPTION
Repeater icons as shown in docs are not visible, needed to add a placeholder text in order to try drag and drop actions or add/remove.